### PR TITLE
Incorporate code to manage YAML input

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
         "start": "node dist/index.js",
         "clean": "rimraf dist",
         "typecheck": "tsc --noEmit",
-        "build": "tsc && chmod 755 dist/index.js"
+        "build": "tsc && chmod 755 dist/index.js",
+        "dev": "ts-node src/index.ts"
     },
     "keywords": [
         "openapi",
@@ -42,16 +43,22 @@
     "dependencies": {
         "@apidevtools/swagger-parser": "^10.1.1",
         "commander": "^13.1.0",
-        "openapi-types": "^12.1.3"
+        "openapi-types": "^12.1.3",
+        "js-yaml": "^4.1.0"
     },
     "devDependencies": {
+        "@types/js-yaml": "^4.0.9",
         "@types/node": "^22.15.2",
         "@typescript-eslint/eslint-plugin": "^8.31.0",
         "@typescript-eslint/parser": "^8.31.0",
         "eslint": "^9.25.1",
         "prettier": "^3.5.3",
         "rimraf": "^6.0.1",
-        "typescript": "^5.8.3"
+        "typescript": "^5.8.3",
+        "ts-node": "^10.9.2",
+        "@modelcontextprotocol/sdk": "^1.10.0",
+        "json-schema-to-zod": "^2.6.1",
+        "zod": "^3.24.3"
     },
     "peerDependencies": {
         "@modelcontextprotocol/sdk": "^1.10.0",


### PR DESCRIPTION
The current version of the project supports JSON input only. I have implemented additional YAML parsing functionality to handle YAML input files. The modifications were made exclusively in `./parser/extract-tools.ts`, and I also added the necessary dependencies in `packages.json`.