### PR TITLE
fix: improve schema parsing for oneOf, anyOf and allOf

### DIFF
--- a/src/parser/extract-tools.ts
+++ b/src/parser/extract-tools.ts
@@ -171,7 +171,35 @@ export function mapOpenApiSchemaToJsonSchema(
   if (typeof schema === 'boolean') return schema;
 
   // Create a copy of the schema to modify
-  const jsonSchema: JSONSchema7 = { ...schema } as any;
+  let jsonSchema: JSONSchema7 = { ...schema } as any;
+
+  if (schema.oneOf || schema.anyOf || schema.allOf) {
+    const oneSchema = structuredClone(schema.oneOf || schema.anyOf || schema.allOf);
+
+    if (oneSchema) {
+      const combinedSchema = mapOpenApiSchemaToJsonSchema(oneSchema[0]);
+      
+      for (let i = 1; i < oneSchema.length; i++) {
+        const mappedSubSchema = mapOpenApiSchemaToJsonSchema(oneSchema[i]);
+        if (typeof mappedSubSchema === 'object' && typeof combinedSchema === 'object') {
+          // Handle enum values
+          if (mappedSubSchema.enum) {
+            if (!combinedSchema.enum) {
+              combinedSchema.enum = [];
+            }
+            // Combine enum values from both schemas
+            const uniqueEnums = new Set([
+              ...combinedSchema.enum,
+              ...(mappedSubSchema.enum || [])
+            ]);
+            combinedSchema.enum = Array.from(uniqueEnums);
+          }
+        }
+      }
+
+      jsonSchema = combinedSchema as JSONSchema7;
+    }
+  }
 
   // Convert integer type to number (JSON Schema compatible)
   if (schema.type === 'integer') jsonSchema.type = 'number';


### PR DESCRIPTION
While testing I encountered an issue with schemas containing `oneOf` prop. The parser needs to merge the props into one array.

I updated the parser to fit our case, but can still break on potential edge cases, like when the oneOf parameters are of different type. My solution takes the first schema type and assumes all of them are the same, another option could be to simply treat them as strings?


Example:

```
"oneOf": [
  {
    "type": "string",
    "example": "eth",
    "default": "eth",
    "enum": [
      "eth",
      "0x1",
    ]
  },
  {
    "type": "string",
    "enum": [
      "solana",
    ]
  }
]
```

Returns

```
{
  "type": "string",
  "example": "eth",
  "default": "eth",
  "enum": [
    "eth",
    "0x1",
    "solana"
  ]
}
```

Tested only for `oneOf`, but should function the same for `anyOf` and `allOf`