### PR TITLE
Consider Path Item-level parameters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "openapi-mcp-generator",
-    "version": "3.1.0",
+    "version": "3.1.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "openapi-mcp-generator",
-            "version": "3.1.0",
+            "version": "3.1.1",
             "license": "MIT",
             "dependencies": {
                 "@apidevtools/swagger-parser": "^10.1.1",
@@ -14,7 +14,7 @@
                 "openapi-types": "^12.1.3"
             },
             "bin": {
-                "openapi-mcp-generator": "dist/index.js"
+                "openapi-mcp-generator": "bin/openapi-mcp-generator.js"
             },
             "devDependencies": {
                 "@types/node": "^22.15.2",

--- a/src/api.ts
+++ b/src/api.ts
@@ -6,7 +6,7 @@
 import SwaggerParser from '@apidevtools/swagger-parser';
 import { OpenAPIV3 } from 'openapi-types';
 import { extractToolsFromApi } from './parser/extract-tools.js';
-import { McpToolDefinition } from './types/index.js';
+import type { McpToolDefinition } from './types/index.js';
 import { determineBaseUrl } from './utils/url.js';
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -85,6 +85,11 @@ program
 // Export the program object for use in bin stub
 export { program };
 
+// Run the program if this file is executed directly
+if (import.meta.url === `file://${process.argv[1]}`) {
+  program.parse();
+}
+
 /**
  * Main function to run the generator
  */

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,8 @@ import {
 import { CliOptions, TransportType } from './types/index.js';
 
 // Export programmatic API
-export { getToolsFromOpenApi, McpToolDefinition, GetToolsOptions } from './api.js';
+export { getToolsFromOpenApi } from './api.js';
+export type { McpToolDefinition, GetToolsOptions } from './api.js';
 
 // Configure CLI
 const program = new Command();


### PR DESCRIPTION
Fixes a bug where Path Item-level parameters are not considered. 

<details>
<summary>
Sample OpenAPI spec
</summary>

```yaml
openapi: 3.0.0
info:
  title: Minimal Parameter Override Example
  version: 1.0.0

paths:
  /items/{itemId}:
    # Path Item Level Parameter
    parameters:
      - name: itemId
        in: path
        required: true
        description: "Path Item Level: The ID of the item."
        schema:
          type: string
          format: uuid
    get:
      summary: Get an item by its ID
      operationId: getItemById
      # Operation Level Parameter (overrides the one at Path Item level)
      parameters:
        - name: itemId # Same name and 'in' location
          in: path
          required: true
          description: "Operation Level: The unique identifier (UUID) for the specific item to retrieve." # Different description
          schema:
            type: string
            format: uuid # Schema could also be different, but description is enough to show override
      responses:
        '200':
          description: Successful operation
          content:
            application/json:
              schema:
                type: object
                properties:
                  id:
                    type: string
                    format: uuid
                  name:
                    type: string
                  retrievedWithDescription:
                    type: string # To show which description would be theoretically used
    put:
      summary: Update an item by its ID
      operationId: updateItemById
      # This operation does NOT override 'itemId', so it inherits the Path Item Level definition.
      requestBody:
        required: true
        content:
          application/json:
            schema:
              type: object
              properties:
                name:
                  type: string
      responses:
        '200':
          description: Item updated successfully
          content:
            application/json:
              schema:
                type: object
                properties:
                  id:
                    type: string
                    format: uuid
                  name:
                    type: string
                  updatedWithDescription:
                    type: string # To show which description would be theoretically used

components: {}
```

</details>

Also makes some additional changes to aid local development:
- Updates `src/index.ts` to support direct execution so that you can run the program using [tsx](https://www.npmjs.com/package/tsx) without having to compile (VS Code's JavaScript Debug terminal lets you step through the Typescript code which is handy)
- Improves type imports to support tsx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The CLI now runs automatically when executed directly, streamlining command-line usage.

- **Refactor**
  - Improved handling of OpenAPI path-level and operation-level parameters to ensure accurate input schema generation.
  - Updated type exports to clearly separate runtime and type-only exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->