### PR TITLE
Declare TypeScript definitions entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
         "README.md",
         "LICENSE"
     ],
+    "types": "dist/index.d.ts",
     "scripts": {
         "start": "node dist/index.js",
         "clean": "rimraf dist",


### PR DESCRIPTION
This adds missing `types` declaration to package.json to ensure this can be imported programmatically as described in the README. Without this, TS code importing this would see the following error:

```
> tsc && chmod 755 build/index.js

src/index.ts:3:37 - error TS2307: Cannot find module 'openapi-mcp-generator' or its corresponding type declarations.

3 import { getToolsFromOpenApi } from 'openapi-mcp-generator';
                                      ~~~~~~~~~~~~~~~~~~~~~~~
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added a TypeScript type definitions entry point to improve compatibility with TypeScript-aware tools and editors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->