### PR TITLE
fix: cannot find the package after building and the problem during th…

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,12 +11,14 @@
     "bin": {
         "openapi-mcp-generator": "./bin/openapi-mcp-generator.js"
     },
+    "main": "dist/index.js",
     "files": [
         "dist",
         "bin",
         "README.md",
         "LICENSE"
     ],
+    "types": "./dist/index.d.ts",
     "scripts": {
         "start": "node dist/index.js",
         "clean": "rimraf dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "openapi-mcp-generator",
-    "version": "3.1.2",
+    "version": "3.1.3",
     "description": "Generates MCP server code from OpenAPI specifications",
     "license": "MIT",
     "author": "Harsha",


### PR DESCRIPTION
- fix the problem when executing the compiled index.js after running `"build": "tsc && chmod 755 build/index.js"`
The problem is shown like this:
```shell
node:internal/modules/esm/resolve:215
  const resolvedOption = FSLegacyMainResolve(packageJsonUrlString, packageConfig.main, baseStringified);
                         ^

Error: Cannot find package '/Users/xxxxx/node_modules/openapi-mcp-generator/index.js' imported from /Users/xxx/build/index.js
    at legacyMainResolve (node:internal/modules/esm/resolve:215:26)
    at packageResolve (node:internal/modules/esm/resolve:841:14)
    at moduleResolve (node:internal/modules/esm/resolve:927:18)
    at defaultResolve (node:internal/modules/esm/resolve:1169:11)
    at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:542:12)
    at ModuleLoader.resolve (node:internal/modules/esm/loader:510:25)
    at ModuleLoader.getModuleJob (node:internal/modules/esm/loader:239:38)
    at ModuleWrap.<anonymous> (node:internal/modules/esm/module_job:96:40)
    at link (node:internal/modules/esm/module_job:95:36) {
  code: 'ERR_MODULE_NOT_FOUND'
}

Node.js v20.18.0
```
- also added the changes from @gusmd https://github.com/harsha-iiiv/openapi-mcp-generator/pull/23

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **Chores**
  - Updated package configuration to specify the main entry point and TypeScript type declarations for improved compatibility with various build and development tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->