### PR TITLE
feature: Add endpoint filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,16 +48,17 @@ openapi-mcp-generator --input path/to/openapi.json --output path/to/output/dir -
 
 ### CLI Options
 
-| Option             | Alias | Description                                                                    | Default                           |
-| ------------------ | ----- | ------------------------------------------------------------------------------ | --------------------------------- |
-| `--input`          | `-i`  | Path or URL to OpenAPI specification (YAML or JSON)                            | **Required**                      |
-| `--output`         | `-o`  | Directory to output the generated MCP project                                  | **Required**                      |
-| `--server-name`    | `-n`  | Name of the MCP server (`package.json:name`)                                   | OpenAPI title or `mcp-api-server` |
-| `--server-version` | `-v`  | Version of the MCP server (`package.json:version`)                             | OpenAPI version or `1.0.0`        |
-| `--base-url`       | `-b`  | Base URL for API requests. Required if OpenAPI `servers` missing or ambiguous. | Auto-detected if possible         |
-| `--transport`      | `-t`  | Transport mode: `"stdio"` (default), `"web"`, or `"streamable-http"`           | `"stdio"`                         |
-| `--port`           | `-p`  | Port for web-based transports                                                  | `3000`                            |
-| `--force`          |       | Overwrite existing files in the output directory without confirmation          | `false`                           |
+| Option              | Alias | Description                                                                              | Default                           |
+| ------------------- | ----- | ---------------------------------------------------------------------------------------- | --------------------------------- |
+| `--input`           | `-i`  | Path or URL to OpenAPI specification (YAML or JSON)                                      | **Required**                      |
+| `--output`          | `-o`  | Directory to output the generated MCP project                                            | **Required**                      |
+| `--server-name`     | `-n`  | Name of the MCP server (`package.json:name`)                                             | OpenAPI title or `mcp-api-server` |
+| `--server-version`  | `-v`  | Version of the MCP server (`package.json:version`)                                       | OpenAPI version or `1.0.0`        |
+| `--base-url`        | `-b`  | Base URL for API requests. Required if OpenAPI `servers` missing or ambiguous.           | Auto-detected if possible         |
+| `--transport`       | `-t`  | Transport mode: `"stdio"` (default), `"web"`, or `"streamable-http"`                     | `"stdio"`                         |
+| `--port`            | `-p`  | Port for web-based transports                                                            | `3000`                            |
+| `--default-include` |       | Default behavior for x-mcp filtering (true=include by default, false=exclude by default) | `true`                            |
+| `--force`           |       | Overwrite existing files in the output directory without confirmation                    | `false`                           |
 
 ## 📦 Programmatic API
 
@@ -164,6 +165,36 @@ Configure auth credentials in your environment:
 | Bearer     | `BEARER_TOKEN_<SCHEME_NAME>`                                                                       |
 | Basic Auth | `BASIC_USERNAME_<SCHEME_NAME>`, `BASIC_PASSWORD_<SCHEME_NAME>`                                     |
 | OAuth2     | `OAUTH_CLIENT_ID_<SCHEME_NAME>`, `OAUTH_CLIENT_SECRET_<SCHEME_NAME>`, `OAUTH_SCOPES_<SCHEME_NAME>` |
+
+---
+
+## 🔎 Filtering Endpoints with OpenAPI Extensions
+
+You can control which operations are exposed as MCP tools using a vendor extension flag `x-mcp`. This extension is supported at the root, path, and operation levels. By default, endpoints are included unless explicitly excluded.
+
+- Extension: `x-mcp: true | false`
+- Default: `true` (include by default)
+- Precedence: operation > path > root (first non-undefined wins)
+- CLI option: `--default-include false` to change default to exclude by default
+
+Examples:
+
+```yaml
+# Optional root-level default
+x-mcp: true
+
+paths:
+  /pets:
+    x-mcp: false # exclude all ops under /pets
+    get:
+      x-mcp: true # include this operation anyway
+
+  /users/{id}:
+    get:
+      # no x-mcp -> included by default
+```
+
+This uses standard OpenAPI extensions (x-… fields). See the OpenAPI Extensions guide for details: https://swagger.io/docs/specification/v3_0/openapi-extensions/
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openapi-mcp-generator",
-  "version": "3.1.2",
+  "version": "3.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openapi-mcp-generator",
-      "version": "3.1.2",
+      "version": "3.1.4",
       "license": "MIT",
       "dependencies": {
         "@apidevtools/swagger-parser": "^10.1.1",

--- a/src/api.ts
+++ b/src/api.ts
@@ -24,6 +24,9 @@ export interface GetToolsOptions {
 
   /** Optional filter function to exclude tools based on custom criteria */
   filterFn?: (tool: McpToolDefinition) => boolean;
+
+  /** Default behavior for x-mcp filtering (default: true = include by default) */
+  defaultInclude?: boolean;
 }
 
 /**
@@ -44,7 +47,7 @@ export async function getToolsFromOpenApi(
       : ((await SwaggerParser.parse(specPathOrUrl)) as OpenAPIV3.Document);
 
     // Extract tools from the API
-    const allTools = extractToolsFromApi(api);
+    const allTools = extractToolsFromApi(api, options.defaultInclude ?? true);
 
     // Add base URL to each tool
     const baseUrl = determineBaseUrl(api, options.baseUrl);

--- a/src/generator/server-code.ts
+++ b/src/generator/server-code.ts
@@ -25,7 +25,7 @@ export function generateMcpServerCode(
   serverVersion: string
 ): string {
   // Extract tools from API
-  const tools = extractToolsFromApi(api);
+  const tools = extractToolsFromApi(api, options.defaultInclude ?? true);
 
   // Determine base URL
   const determinedBaseUrl = determineBaseUrl(api, options.baseUrl);

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,6 +72,11 @@ program
     'Port for web or streamable-http transport (default: 3000)',
     (val) => parseInt(val, 10)
   )
+  .option(
+    '--default-include <boolean>',
+    'Default behavior for x-mcp filtering (default: true = include by default, false = exclude by default)',
+    (val) => (val === 'false' ? false : true)
+  )
   .option('--force', 'Overwrite existing files without prompting')
   .version(pkg.version) // Match package.json version
   .action((options) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ import {
 
 // Import types
 import { CliOptions, TransportType } from './types/index.js';
+import { normalizeBoolean } from './utils/helpers.js';
 import pkg from '../package.json' with { type: 'json' };
 
 // Export programmatic API
@@ -75,7 +76,14 @@ program
   .option(
     '--default-include <boolean>',
     'Default behavior for x-mcp filtering (default: true = include by default, false = exclude by default)',
-    (val) => (val === 'false' ? false : true)
+    (val) => {
+      const parsed = normalizeBoolean(val);
+      if (typeof parsed === 'boolean') return parsed;
+      console.warn(
+        `Invalid value for --default-include: "${val}". Expected true/false (case-insensitive). Using default: true.`
+      );
+      return true;
+    }
   )
   .option('--force', 'Overwrite existing files without prompting')
   .version(pkg.version) // Match package.json version

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -29,6 +29,8 @@ export interface CliOptions {
   transport?: TransportType;
   /** Server port (for web and streamable-http transports) */
   port?: number;
+  /** Default behavior for x-mcp filtering (default: true = include by default) */
+  defaultInclude?: boolean;
 }
 
 /**

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,6 +1,7 @@
 /**
  * General helper utilities for OpenAPI to MCP generator
  */
+import { OpenAPIV3 } from 'openapi-types';
 
 /**
  * Safely stringify a JSON object with proper error handling
@@ -109,4 +110,38 @@ export function formatComment(str: string, maxLineLength: number = 80): string {
   }
 
   return lines.join('\n * ');
+}
+
+/**
+ * Normalize a value to boolean if it looks like a boolean; otherwise undefined.
+ */
+export function normalizeBoolean(value: unknown): boolean | undefined {
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    return normalized === 'true' ? true : normalized === 'false' ? false : undefined;
+  }
+  return undefined;
+}
+
+/**
+ * Determine if an operation should be included in MCP generation based on x-mcp.
+ * Precedence: operation > path > root; uses provided default when all undefined.
+ */
+export function shouldIncludeOperationForMcp(
+  api: OpenAPIV3.Document,
+  pathItem: OpenAPIV3.PathItemObject,
+  operation: OpenAPIV3.OperationObject,
+  defaultInclude: boolean = true
+): boolean {
+  const opVal = normalizeBoolean((operation as any)['x-mcp']);
+  if (typeof opVal !== 'undefined') return opVal;
+
+  const pathVal = normalizeBoolean((pathItem as any)['x-mcp']);
+  if (typeof pathVal !== 'undefined') return pathVal;
+
+  const rootVal = normalizeBoolean((api as any)['x-mcp']);
+  if (typeof rootVal !== 'undefined') return rootVal;
+
+  return defaultInclude; // use provided default
 }

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -134,14 +134,38 @@ export function shouldIncludeOperationForMcp(
   operation: OpenAPIV3.OperationObject,
   defaultInclude: boolean = true
 ): boolean {
-  const opVal = normalizeBoolean((operation as any)['x-mcp']);
+  const opRaw = (operation as any)['x-mcp'];
+  const opVal = normalizeBoolean(opRaw);
   if (typeof opVal !== 'undefined') return opVal;
+  if (typeof opRaw !== 'undefined') {
+    console.warn(
+      `Invalid x-mcp value on operation '${operation.operationId ?? '[no operationId]'}':`,
+      opRaw,
+      `-> expected boolean or 'true'/'false'. Falling back to path/root/default.`
+    );
+  }
 
-  const pathVal = normalizeBoolean((pathItem as any)['x-mcp']);
+  const pathRaw = (pathItem as any)['x-mcp'];
+  const pathVal = normalizeBoolean(pathRaw);
   if (typeof pathVal !== 'undefined') return pathVal;
+  if (typeof pathRaw !== 'undefined') {
+    console.warn(
+      `Invalid x-mcp value on path item:`,
+      pathRaw,
+      `-> expected boolean or 'true'/'false'. Falling back to root/default.`
+    );
+  }
 
-  const rootVal = normalizeBoolean((api as any)['x-mcp']);
+  const rootRaw = (api as any)['x-mcp'];
+  const rootVal = normalizeBoolean(rootRaw);
   if (typeof rootVal !== 'undefined') return rootVal;
+  if (typeof rootRaw !== 'undefined') {
+    console.warn(
+      `Invalid x-mcp value at API root:`,
+      rootRaw,
+      `-> expected boolean or 'true'/'false'. Falling back to defaultInclude=${defaultInclude}.`
+    );
+  }
 
   return defaultInclude;
 }

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -143,5 +143,5 @@ export function shouldIncludeOperationForMcp(
   const rootVal = normalizeBoolean((api as any)['x-mcp']);
   if (typeof rootVal !== 'undefined') return rootVal;
 
-  return defaultInclude; // use provided default
+  return defaultInclude;
 }


### PR DESCRIPTION
# Add x-mcp extension filtering for endpoint selection

## What this PR does

This PR adds support for filtering which OpenAPI operations are exposed as MCP tools using the `x-mcp` extension. This allows API providers to control which endpoints should be available in the generated MCP server.

## Features

- **x-mcp extension support**: Add `x-mcp: true|false` to any operation, path, or root level
- **Precedence rules**: operation > path > root (first non-undefined wins)
- **Default behavior**: Include by default (backward compatible)
- **CLI option**: `--default-include false` to change default to exclude by default
- **Programmatic API**: `defaultInclude` option in `getToolsFromOpenApi`

## Usage examples

### Basic filtering

```yaml
paths:
  /pets:
    x-mcp: false # exclude all operations under /pets
    get:
      x-mcp: true # but explicitly include this one
```

### Opt-in model (exclude by default)

```bash
# Only include operations explicitly marked with x-mcp: true
openapi-mcp-generator --input spec.yaml --output output-dir --default-include false
```

### Programmatic usage

```javascript
// Exclude by default, only include explicit x-mcp: true
const tools = await getToolsFromOpenApi("./spec.yaml", {
  defaultInclude: false,
});
```

## Implementation details

- Added `shouldIncludeOperationForMcp()` helper in `src/utils/helpers.ts`
- Updated `extractToolsFromApi()` to respect x-mcp filtering
- Added `--default-include` CLI option
- Enhanced error handling with warnings for invalid x-mcp values
- Updated README with documentation and examples

## Backward compatibility

- No breaking changes to existing APIs. Existing OpenAPI specs without `x-mcp` extensions work unchanged.

## References

- [OpenAPI Extensions documentation](https://swagger.io/docs/specification/v3_0/openapi-extensions/)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added CLI option --default-include to control whether endpoints are included as tools by default (true by default).
  - Introduced filtering of endpoints using the x-mcp OpenAPI extension with precedence: operation > path > root. CLI can override defaults.

- Documentation
  - Added “Filtering Endpoints with OpenAPI Extensions” section with examples, default behavior, and precedence details.
  - Improved CLI options table formatting for readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->