### PR TITLE
Handle Array type query params

### DIFF
--- a/src/utils/security.ts
+++ b/src/utils/security.ts
@@ -412,7 +412,8 @@ async function executeApiTool(
                 urlPath = urlPath.replace(\`{\${param.name}}\`, encodeURIComponent(String(value)));
             }
             else if (param.in === 'query') {
-                queryParams[param.name] = value;
+                // Convert arrays to comma-separated strings for query parameters
+                queryParams[param.name] = Array.isArray(value) ? value.join(',') : value;
             }
             else if (param.in === 'header') {
                 headers[param.name.toLowerCase()] = String(value);

--- a/src/utils/security.ts
+++ b/src/utils/security.ts
@@ -413,8 +413,12 @@ async function executeApiTool(
             }
             else if (param.in === 'query') {
                 // Convert arrays to comma-separated strings for query parameters
-                queryParams[param.name] = Array.isArray(value) ? value.join(',') : value;
-            }
+                queryParams[param.name] = Array.isArray(value)
+                  ? value
+                      .filter((v) => v !== undefined && v !== null)
+                      .map((v) => String(v))
+                      .join(',')
+                  : value;            }
             else if (param.in === 'header') {
                 headers[param.name.toLowerCase()] = String(value);
             }


### PR DESCRIPTION
Fixed an issue when extracting tools where if the query param value was an array, it would not get serialized by axios properly. 

For example, if I need to specify the fields to return for an api call, I want this:
  - ?fields=value1,value2,value3
  
But it was doing this:
- ?fields[]=value1&fields[]=value2&fields[]=value3

This fix checks if the query param value is an array, and if it is, it joins them into a comma separated list. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Arrays passed as query parameters are now sent as comma-separated values, improving compatibility with APIs that expect CSV lists. Non-array parameters unchanged. Users should see more reliable filtering and pagination when supplying multiple values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->