### PR TITLE
Allow insecure HTTPS connections (self-signed certificates)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ openapi-mcp-generator --input path/to/openapi.json --output path/to/output/dir -
 | `--port`            | `-p`  | Port for web-based transports                                                                                                                  | `3000`                            |
 | `--default-include` |       | Default behavior for x-mcp filtering. Accepts `true` or `false` (case-insensitive). `true` = include by default, `false` = exclude by default. | `true`                            |
 | `--force`           |       | Overwrite existing files in the output directory without confirmation                                                                          | `false`                           |
-| `--insecure`        | `-k`  | Allow insecure HTTPS connections (self-signed certificates) | `false`                           |
+| `--insecure`        | `-k`  | Allow insecure HTTPS connections (self-signed certificates)                                                                                    | `false`                           |
 
 ## 📦 Programmatic API
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ openapi-mcp-generator --input path/to/openapi.json --output path/to/output/dir -
 | `--port`            | `-p`  | Port for web-based transports                                                                                                                  | `3000`                            |
 | `--default-include` |       | Default behavior for x-mcp filtering. Accepts `true` or `false` (case-insensitive). `true` = include by default, `false` = exclude by default. | `true`                            |
 | `--force`           |       | Overwrite existing files in the output directory without confirmation                                                                          | `false`                           |
+| `--insecure`        | `-k`  | Allow insecure HTTPS connections (self-signed certificates) | `false`                           |
 
 ## 📦 Programmatic API
 

--- a/src/generator/server-code.ts
+++ b/src/generator/server-code.ts
@@ -35,7 +35,7 @@ export function generateMcpServerCode(
 
   // Generate code for API tool execution
   const executeApiToolFunctionCode = generateExecuteApiToolFunction(
-    api.components?.securitySchemes
+    api.components?.securitySchemes, options.insecure,
   );
 
   // Generate code for request handlers
@@ -105,6 +105,7 @@ import {
 import { z, ZodError } from 'zod';
 import { jsonSchemaToZod } from 'json-schema-to-zod';
 import axios, { type AxiosRequestConfig, type AxiosError } from 'axios';
+import https from 'https';
 
 /**
  * Type definition for JSON objects

--- a/src/generator/server-code.ts
+++ b/src/generator/server-code.ts
@@ -35,7 +35,8 @@ export function generateMcpServerCode(
 
   // Generate code for API tool execution
   const executeApiToolFunctionCode = generateExecuteApiToolFunction(
-    api.components?.securitySchemes, options.insecure,
+    api.components?.securitySchemes,
+    options.insecure
   );
 
   // Generate code for request handlers
@@ -105,7 +106,7 @@ import {
 import { z, ZodError } from 'zod';
 import { jsonSchemaToZod } from 'json-schema-to-zod';
 import axios, { type AxiosRequestConfig, type AxiosError } from 'axios';
-import https from 'https';
+${options.insecure ? "import https from 'https';" : ''}
 
 /**
  * Type definition for JSON objects

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,10 +87,8 @@ program
     true
   )
   .option('--force', 'Overwrite existing files without prompting')
-    .option(
-    '-k, --insecure',
-    'Allow insecure HTTPS connections (self-signed certificates)',
-    (val) => normalizeBoolean(val)
+  .option('-k, --insecure', 'Allow insecure HTTPS connections (self-signed certificates)', (val) =>
+    normalizeBoolean(val)
   )
   .version(pkg.version) // Match package.json version
   .action((options) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,6 +87,11 @@ program
     true
   )
   .option('--force', 'Overwrite existing files without prompting')
+    .option(
+    '-k, --insecure',
+    'Allow insecure HTTPS connections (self-signed certificates)',
+    (val) => normalizeBoolean(val)
+  )
   .version(pkg.version) // Match package.json version
   .action((options) => {
     runGenerator(options).catch((error) => {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -35,6 +35,8 @@ export interface CliOptions {
    * false = exclude by default unless x-mcp explicitly enables.
    */
   defaultInclude?: boolean;
+  /** Allow insecure HTTPS connections (self-signed certificates) */
+  insecure?: boolean;
 }
 
 /**

--- a/src/utils/security.ts
+++ b/src/utils/security.ts
@@ -202,7 +202,8 @@ async function acquireOAuth2Token(schemeName: string, scheme: any): Promise<stri
  * @returns Generated code for the execute API tool function
  */
 export function generateExecuteApiToolFunction(
-  securitySchemes?: OpenAPIV3.ComponentsObject['securitySchemes'], insecure?: boolean
+  securitySchemes?: OpenAPIV3.ComponentsObject['securitySchemes'],
+  insecure?: boolean
 ): string {
   // Generate OAuth2 token acquisition function
   const oauth2TokenAcquisitionCode = generateOAuth2TokenAcquisitionCode(insecure);

--- a/src/utils/security.ts
+++ b/src/utils/security.ts
@@ -82,7 +82,7 @@ export function generateHttpSecurityCode(): string {
  *
  * @returns Generated code for OAuth2 token acquisition
  */
-export function generateOAuth2TokenAcquisitionCode(): string {
+export function generateOAuth2TokenAcquisitionCode(insecure?: boolean): string {
   return `
 /**
  * Type definition for cached OAuth tokens
@@ -165,7 +165,8 @@ async function acquireOAuth2Token(schemeName: string, scheme: any): Promise<stri
                 'Content-Type': 'application/x-www-form-urlencoded',
                 'Authorization': \`Basic \${Buffer.from(\`\${clientId}:\${clientSecret}\`).toString('base64')}\`
             },
-            data: formData.toString()
+            data: formData.toString(),
+            ${insecure ? 'httpsAgent: new https.Agent({ rejectUnauthorized: false })' : ''}
         });
         
         // Process the response
@@ -201,10 +202,10 @@ async function acquireOAuth2Token(schemeName: string, scheme: any): Promise<stri
  * @returns Generated code for the execute API tool function
  */
 export function generateExecuteApiToolFunction(
-  securitySchemes?: OpenAPIV3.ComponentsObject['securitySchemes']
+  securitySchemes?: OpenAPIV3.ComponentsObject['securitySchemes'], insecure?: boolean
 ): string {
   // Generate OAuth2 token acquisition function
-  const oauth2TokenAcquisitionCode = generateOAuth2TokenAcquisitionCode();
+  const oauth2TokenAcquisitionCode = generateOAuth2TokenAcquisitionCode(insecure);
 
   // Generate security handling code for checking, applying security
   const securityCode = `
@@ -443,6 +444,7 @@ ${securityCode}
       params: queryParams, 
       headers: headers,
       ...(requestBodyData !== undefined && { data: requestBodyData }),
+      ${insecure ? 'httpsAgent: new https.Agent({ rejectUnauthorized: false })' : ''}
     };
 
     // Log request info to stderr (doesn't affect MCP output)


### PR DESCRIPTION
Add a command line option to allow insecure HTTPS connections.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added --insecure (-k) CLI option to allow connections to servers with self-signed HTTPS certificates.
  * Generated requests (including OAuth2 token acquisition and API calls) honor this flag to bypass TLS verification when enabled.
  * Default behavior remains secure; TLS verification is unchanged unless explicitly enabled.

* **Documentation**
  * Updated CLI options in README to include the new --insecure (-k) flag and its default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->