### PR TITLE
tool: expose the `deprecated` attribute

### DIFF
--- a/src/parser/extract-tools.ts
+++ b/src/parser/extract-tools.ts
@@ -90,6 +90,8 @@ export function extractToolsFromApi(
       const securityRequirements =
         operation.security === null ? globalSecurity : operation.security || globalSecurity;
 
+      const deprecated = operation.deprecated || false;
+
       // Create the tool definition
       tools.push({
         name: finalToolName,
@@ -102,6 +104,7 @@ export function extractToolsFromApi(
         requestBodyContentType,
         securityRequirements,
         operationId: baseName,
+        deprecated,
       });
     }
   }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -62,6 +62,8 @@ export interface McpToolDefinition {
   securityRequirements: OpenAPIV3.SecurityRequirementObject[];
   /** Original operation ID from the OpenAPI spec */
   operationId: string;
+  /** OpenAPI deprecated attribute **/
+  deprecated: boolean;
 }
 
 /**


### PR DESCRIPTION
Expose the `deprecated` attribute and default to `false`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tool definitions now include a deprecated flag (defaults to false) derived from operation metadata.
  * Deprecation status is propagated to generated tools so clients and UIs can detect and display deprecated tools.
  * Schema extended with a deprecated field; behavior unchanged for tools not marked deprecated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->