### PR TITLE
Fixes "PORT" environment variable usage and proposes the "--generate-lib" CLI option

### DIFF
--- a/src/generator/server-code.ts
+++ b/src/generator/server-code.ts
@@ -45,13 +45,14 @@ export function generateMcpServerCode(
   // Determine which transport to include
   let transportImport = '';
   let transportCode = '';
+  const webServicerPortNumberStatement = `${options.port ?? "process.env['PORT'] === undefined ? undefined : parseInt(process.env['PORT'], 10)"}`;
 
   switch (options.transport) {
     case 'web':
       transportImport = `\nimport { setupWebServer } from "./web-server.js";`;
       transportCode = `// Set up Web Server transport
   try {
-    await setupWebServer(server, ${options.port || 3000});
+    await setupWebServer(server, ${webServicerPortNumberStatement});
   } catch (error) {
     console.error("Error setting up web server:", error);
     process.exit(1);
@@ -61,7 +62,7 @@ export function generateMcpServerCode(
       transportImport = `\nimport { setupStreamableHttpServer } from "./streamable-http.js";`;
       transportCode = `// Set up StreamableHTTP transport
   try {
-    await setupStreamableHttpServer(server, ${options.port || 3000});
+    await setupStreamableHttpServer(server, ${webServicerPortNumberStatement});
   } catch (error) {
     console.error("Error setting up StreamableHTTP server:", error);
     process.exit(1);
@@ -89,8 +90,8 @@ export function generateMcpServerCode(
  */
 
 // Load environment variables from .env file
-import dotenv from 'dotenv';
-dotenv.config();
+import { config } from 'dotenv';
+config();
 
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";

--- a/src/generator/server-code.ts
+++ b/src/generator/server-code.ts
@@ -82,6 +82,25 @@ export function generateMcpServerCode(
       break;
   }
 
+  const mainDeclaration= options.generateLib === true ? '' : `
+/**
+ * Cleanup function for graceful shutdown
+ */
+async function cleanup() {
+    console.error("Shutting down MCP server...");
+    process.exit(0);
+}
+
+// Register signal handlers
+process.on('SIGINT', cleanup);
+process.on('SIGTERM', cleanup);
+
+// Start the server
+main().catch((error) => {
+  console.error("Fatal error in main execution:", error);
+  process.exit(1);
+});`;
+
   // Generate the full server code
   return `#!/usr/bin/env node
 /**
@@ -160,27 +179,11 @@ ${executeApiToolFunctionCode}
 /**
  * Main function to start the server
  */
-async function main() {
+${options.generateLib === true ? 'export ' : ''}async function main() {
 ${transportCode}
 }
 
-/**
- * Cleanup function for graceful shutdown
- */
-async function cleanup() {
-    console.error("Shutting down MCP server...");
-    process.exit(0);
-}
-
-// Register signal handlers
-process.on('SIGINT', cleanup);
-process.on('SIGTERM', cleanup);
-
-// Start the server
-main().catch((error) => {
-  console.error("Fatal error in main execution:", error);
-  process.exit(1);
-});
+${mainDeclaration}
 
 /**
  * Formats API errors for better readability

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,6 +74,11 @@ program
     (val) => parseInt(val, 10)
   )
   .option(
+    '-l, --generate-lib <number>',
+    'Indicates whether a library should be generated and hence the \'main\' method not invoked (default: false)',
+    (val) => val === 'true'
+  )
+  .option(
     '--default-include <boolean>',
     'Default behavior for x-mcp filtering (true|false, case-insensitive). Default: true (include by default), false = exclude by default',
     (val) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,9 +74,10 @@ program
     (val) => parseInt(val, 10)
   )
   .option(
-    '-l, --generate-lib <number>',
+    '-l, --generate-lib <boolean>',
     'Indicates whether a library should be generated and hence the \'main\' method not invoked (default: false)',
-    (val) => val === 'true'
+    (val) => normalizeBoolean(val),
+    false
   )
   .option(
     '--default-include <boolean>',

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -29,6 +29,8 @@ export interface CliOptions {
   transport?: TransportType;
   /** Server port (for web and streamable-http transports) */
   port?: number;
+  /** Whether the generated code should invoke the main method or expose the main method as a library */
+  generateLib?: boolean;
   /**
    * Default behavior for x-mcp filtering.
    * true (default) = include by default when x-mcp is missing or invalid;


### PR DESCRIPTION
- The generated code does not use the `PORT` environment variable when the `--port` CLI is not defined and forces the port to be 3000, while the `setupWebServer` function `port` argument already has this default value: proposes to resort to the `PORT` environment variable in that case.
- Proposes a new `--generate-lib` CLI option, which causes the generated `main()` function to be exported and removing the clean-up code generation, so as to be able to import and run than `main()` function is an existing code, just like a library.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a CLI option to generate library-style output that exposes (rather than auto-invokes) the main entrypoint.

- Refactor
  - Standardized environment variable initialization for more consistent startup.
  - Implemented dynamic port resolution across transports to avoid hard-coded defaults.
  - Centralized startup/cleanup with graceful SIGINT/SIGTERM handling and clearer fatal-error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->