### PR TITLE
Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ openapi-mcp-generator --input path/to/openapi.json --output path/to/output/dir -
 | `--port`            | `-p`  | Port for web-based transports                                                                                                                  | `3000`                            |
 | `--default-include` |       | Default behavior for x-mcp filtering. Accepts `true` or `false` (case-insensitive). `true` = include by default, `false` = exclude by default. | `true`                            |
 | `--force`           |       | Overwrite existing files in the output directory without confirmation                                                                          | `false`                           |
+| `--simplifyTypes`  | `-st` | Flatten single-element type arrays in the JSON schema to their single value    | `false`                           |
 
 ## 📦 Programmatic API
 

--- a/src/generator/server-code.ts
+++ b/src/generator/server-code.ts
@@ -25,7 +25,7 @@ export function generateMcpServerCode(
   serverVersion: string
 ): string {
   // Extract tools from API
-  const tools = extractToolsFromApi(api, options.defaultInclude ?? true);
+  const tools = extractToolsFromApi(api, options.defaultInclude ?? true, options.simplifyTypes);
 
   // Determine base URL
   const determinedBaseUrl = determineBaseUrl(api, options.baseUrl);

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,6 +87,10 @@ program
     true
   )
   .option('--force', 'Overwrite existing files without prompting')
+  .option(
+    '-st, --simplifyTypes',
+    'Flatten single-element type arrays in the JSON schema to their single value'
+  )
   .version(pkg.version) // Match package.json version
   .action((options) => {
     runGenerator(options).catch((error) => {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -35,6 +35,8 @@ export interface CliOptions {
    * false = exclude by default unless x-mcp explicitly enables.
    */
   defaultInclude?: boolean;
+  /** Flatten single-element type arrays in the JSON schema to their single value */
+  simplifyTypes?: string;
 }
 
 /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--simplifyTypes` (`-st`) CLI option to flatten single-element type arrays in JSON schemas to their primitive types for cleaner schema output.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->