### PR TITLE
fix: truncate tool names exceeding 64 character limit

### DIFF
--- a/src/parser/extract-tools.ts
+++ b/src/parser/extract-tools.ts
@@ -68,6 +68,12 @@ export function extractToolsFromApi(
       // Sanitize the name to be MCP-compatible (only a-z, 0-9, _, -)
       baseName = baseName.replace(/\./g, '_').replace(/[^a-z0-9_-]/gi, '_');
 
+      // Claude Desktop enforces a 64-character limit on tool names
+      const MAX_TOOL_NAME_LENGTH = 64;
+      if (baseName.length > MAX_TOOL_NAME_LENGTH) {
+        baseName = baseName.substring(0, MAX_TOOL_NAME_LENGTH);
+      }
+
       let finalToolName = baseName;
       let counter = 1;
       while (usedNames.has(finalToolName)) {


### PR DESCRIPTION
Fixes #4 — truncates MCP tool names to 64 characters to comply with Claude Desktop's limit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tool names are now truncated to 64 characters to ensure compatibility with Claude Desktop constraints, preventing potential issues with tools that have longer names.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/harsha-iiiv/openapi-mcp-generator/pull/64?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->