### PR TITLE
Fix Basic auth failing when password is empty

### DIFF
--- a/src/utils/security.ts
+++ b/src/utils/security.ts
@@ -70,8 +70,8 @@ export function generateHttpSecurityCode(): string {
         else if (scheme.scheme?.toLowerCase() === 'basic') {
             const username = process.env[\`${getEnvVarName(schemeName, 'BASIC_USERNAME')}\`];
             const password = process.env[\`${getEnvVarName(schemeName, 'BASIC_PASSWORD')}\`];
-            if (username && password) {
-                headers['authorization'] = \`Basic \${Buffer.from(\`\${username}:\${password}\`).toString('base64')}\`;
+            if (username != null) {
+                headers['authorization'] = \`Basic \${Buffer.from(\`\${username}:\${password ?? ''}\`).toString('base64')}\`;
             }
         }
     }`;
@@ -227,8 +227,7 @@ export function generateExecuteApiToolFunction(
                     return !!process.env[\`BEARER_TOKEN_\${schemeName.replace(/[^a-zA-Z0-9]/g, '_').toUpperCase()}\`];
                 }
                 else if (scheme.scheme?.toLowerCase() === 'basic') {
-                    return !!process.env[\`BASIC_USERNAME_\${schemeName.replace(/[^a-zA-Z0-9]/g, '_').toUpperCase()}\`] && 
-                           !!process.env[\`BASIC_PASSWORD_\${schemeName.replace(/[^a-zA-Z0-9]/g, '_').toUpperCase()}\`];
+                    return process.env[\`BASIC_USERNAME_\${schemeName.replace(/[^a-zA-Z0-9]/g, '_').toUpperCase()}\`] != null;
                 }
             }
             
@@ -297,8 +296,8 @@ export function generateExecuteApiToolFunction(
                 else if (scheme.scheme?.toLowerCase() === 'basic') {
                     const username = process.env[\`BASIC_USERNAME_\${schemeName.replace(/[^a-zA-Z0-9]/g, '_').toUpperCase()}\`];
                     const password = process.env[\`BASIC_PASSWORD_\${schemeName.replace(/[^a-zA-Z0-9]/g, '_').toUpperCase()}\`];
-                    if (username && password) {
-                        headers['authorization'] = \`Basic \${Buffer.from(\`\${username}:\${password}\`).toString('base64')}\`;
+                    if (username != null) {
+                        headers['authorization'] = \`Basic \${Buffer.from(\`\${username}:\${password ?? ''}\`).toString('base64')}\`;
                         console.error(\`Applied Basic authentication for '\${schemeName}'\`);
                     }
                 }


### PR DESCRIPTION
## Summary

- HTTP Basic auth silently fails when the password env var is empty or unset, because the check `if (username && password)` treats empty string as falsy
- Some APIs use Basic auth with only a username and no password — e.g., [Dropbox Sign](https://developers.hellosign.com/) sends the API key as the username with an empty password. This is a valid pattern per [RFC 7617](https://datatracker.ietf.org/doc/html/rfc7617) (the HTTP Basic auth spec)
- Fixed all three locations in `src/utils/security.ts`: the availability check, the generated auth application code, and `generateHttpSecurityCode()`

## What changed

The condition `if (username && password)` → `if (username != null)`, and the password is defaulted via `password ?? ''` so the Base64 encoding always works.

## How I found it

Generated an MCP server from the [Dropbox Sign OpenAPI spec](https://github.com/hellosign/hellosign-openapi). Every API call returned 401 Unauthorized despite the API key being correctly set in `BASIC_USERNAME_API_KEY`. The empty `BASIC_PASSWORD_API_KEY` caused the auth header to never be applied.

## Test plan

- [x] `npm run build` passes
- [ ] Generate a server from an OpenAPI spec that uses HTTP Basic auth with empty password (e.g., Dropbox Sign) and verify requests are authenticated

🤖 Generated with [Claude Code](https://claude.com/claude-code)