### PR TITLE
fix: v4.0.1 — SSRF guard URL-input regression + multi-file $ref resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.0.1] - 2026-06-14
+
+### Fixed
+
+- The SSRF guard added in 4.0.0 disabled the HTTP resolver for the whole parse,
+  which also blocked fetching the user-supplied input when it was an `http(s)`
+  URL — e.g. `openapi-mcp-generator -i https://.../openapi.json` failed with
+  "Unable to resolve $ref pointer". The guard now only rejects external `$ref`s
+  embedded inside the spec; the trusted input URL/path still loads.
+- Relative `$ref`s in multi-file specs (e.g. `./refs/schemas.json#/Pet`) now
+  resolve against the spec's directory instead of the process working directory.
+- `getToolsFromOpenApi` (programmatic API) no longer hits the same URL-input
+  regression; it follows the same parse → scan → dereference flow with SSRF
+  protection intact.
+
 ## [4.0.0] - 2026-06-13
 
 A hardening-and-configurability release. All changes are backward compatible:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openapi-mcp-generator",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Generates MCP server code from OpenAPI specifications",
   "license": "MIT",
   "author": "Harsha",

--- a/src/api.ts
+++ b/src/api.ts
@@ -8,7 +8,7 @@ import { OpenAPIV3 } from 'openapi-types';
 import { extractToolsFromApi } from './parser/extract-tools.js';
 import { McpToolDefinition } from './types/index.js';
 import { determineBaseUrl } from './utils/url.js';
-import { assertNoExternalRefs } from './utils/parser-security.js';
+import { assertNoExternalRefs, parseSpecSecurely } from './utils/parser-security.js';
 
 /**
  * Options for generating the MCP tools
@@ -59,24 +59,23 @@ export async function getToolsFromOpenApi(
 ): Promise<McpToolDefinition[]> {
   try {
     const allowExternalRefs = options.allowExternalRefs ?? false;
-    // Resolve local/internal refs only when external refs are disallowed.
-    const resolverOptions = allowExternalRefs ? {} : { resolve: { http: false as const } };
 
-    // Parse the OpenAPI spec.
-    // Honor `dereference` for all input types, including a pre-parsed document
-    // (SwaggerParser accepts an API object as well as a path/URL string).
-    const api = options.dereference
-      ? ((await SwaggerParser.dereference(
-          specPathOrUrl as string,
-          resolverOptions
-        )) as OpenAPIV3.Document)
-      : isOpenApiDocument(specPathOrUrl)
-        ? specPathOrUrl
-        : ((await SwaggerParser.parse(specPathOrUrl, resolverOptions)) as OpenAPIV3.Document);
-
-    // Guard against SSRF via external $ref unless explicitly allowed.
-    if (!allowExternalRefs) {
-      assertNoExternalRefs(api);
+    let api: OpenAPIV3.Document;
+    if (options.dereference) {
+      // Dereference path: parseSpecSecurely loads the (trusted) entry document —
+      // including http(s) URLs — then enforces the SSRF guard before resolving.
+      api = await parseSpecSecurely(specPathOrUrl, allowExternalRefs);
+    } else if (isOpenApiDocument(specPathOrUrl)) {
+      // Pre-parsed document, no dereference requested: use as-is.
+      api = specPathOrUrl;
+      if (!allowExternalRefs) assertNoExternalRefs(api);
+    } else {
+      // Parse-only (no dereference): fetch/read the entry document (http allowed
+      // so a URL input loads), then enforce the SSRF guard on the raw tree.
+      api = (await SwaggerParser.parse(
+        specPathOrUrl as Parameters<typeof SwaggerParser.parse>[0]
+      )) as OpenAPIV3.Document;
+      if (!allowExternalRefs) assertNoExternalRefs(api);
     }
 
     // Extract tools from the API

--- a/src/utils/parser-security.ts
+++ b/src/utils/parser-security.ts
@@ -75,17 +75,29 @@ export function assertNoExternalRefs(node: unknown, seen: WeakSet<object> = new 
   }
 }
 
+/** True if the input is an http(s) URL string. */
+function isHttpUrlInput(input: string | OpenAPIV3.Document): input is string {
+  return typeof input === 'string' && /^https?:\/\//i.test(input.trim());
+}
+
 /**
  * Parse and dereference an OpenAPI spec with optional SSRF protection.
  *
  * The SSRF protection targets external `$ref`s embedded *inside* the spec, not
- * the user-supplied input itself: a URL passed as the input is trusted (the
- * user typed it) and must still be fetched. So when `allowExternalRefs` is
- * false (the default) we:
- *   1. Parse the input normally (the entry document — a URL input is fetched).
+ * the user-supplied input itself: a URL/path passed as the input is trusted
+ * (the user typed it) and must still load. When `allowExternalRefs` is false
+ * (the default) we:
+ *   1. Parse the entry document (http allowed so a URL input is fetched).
  *   2. Scan the parsed tree and reject any external http(s) `$ref`.
- *   3. Dereference the already-loaded object with the http resolver disabled —
- *      safe because step 2 guaranteed no external refs remain to follow.
+ *   3. Dereference with the http resolver disabled — safe because step 2
+ *      guaranteed no external refs remain to follow.
+ *
+ * Step 3 dereferences from the ORIGINAL local-path/object input (not the parsed
+ * object) so relative file `$ref`s (e.g. `./schemas.json#/MyType`) resolve
+ * against the spec's directory rather than the process cwd. For URL inputs,
+ * which can't be re-fetched once http is disabled, it dereferences the parsed
+ * object instead (URL specs are single-file or use absolute refs already
+ * rejected in step 2).
  *
  * @param input Path, URL, or pre-parsed document
  * @param allowExternalRefs Permit external http(s) `$ref` resolution
@@ -109,10 +121,14 @@ export async function parseSpecSecurely(
   // 2. Reject any external http(s) $ref embedded in the spec (SSRF guard).
   assertNoExternalRefs(parsed);
 
-  // 3. Dereference the already-loaded object with http disabled. No external
-  //    refs remain after the scan, so only local/internal refs are resolved and
-  //    nothing reaches out over the network.
-  return (await SwaggerParser.dereference(parsed, {
+  // 3. Dereference with http disabled. For local-path/object inputs, pass the
+  //    ORIGINAL input so relative file refs resolve against the spec directory;
+  //    for URL inputs (which can't be re-fetched with http off) dereference the
+  //    already-parsed object.
+  const dereferenceInput: Parameters<typeof SwaggerParser.dereference>[0] = isHttpUrlInput(input)
+    ? (parsed as unknown as Parameters<typeof SwaggerParser.dereference>[0])
+    : apiInput;
+  return (await SwaggerParser.dereference(dereferenceInput, {
     resolve: { http: false },
   })) as OpenAPIV3.Document;
 }

--- a/src/utils/parser-security.ts
+++ b/src/utils/parser-security.ts
@@ -78,9 +78,14 @@ export function assertNoExternalRefs(node: unknown, seen: WeakSet<object> = new 
 /**
  * Parse and dereference an OpenAPI spec with optional SSRF protection.
  *
- * When `allowExternalRefs` is false (the default), the spec is first parsed
- * without resolving external references, scanned for external http(s) refs,
- * and only then dereferenced with the http resolver disabled.
+ * The SSRF protection targets external `$ref`s embedded *inside* the spec, not
+ * the user-supplied input itself: a URL passed as the input is trusted (the
+ * user typed it) and must still be fetched. So when `allowExternalRefs` is
+ * false (the default) we:
+ *   1. Parse the input normally (the entry document — a URL input is fetched).
+ *   2. Scan the parsed tree and reject any external http(s) `$ref`.
+ *   3. Dereference the already-loaded object with the http resolver disabled —
+ *      safe because step 2 guaranteed no external refs remain to follow.
  *
  * @param input Path, URL, or pre-parsed document
  * @param allowExternalRefs Permit external http(s) `$ref` resolution
@@ -97,16 +102,17 @@ export async function parseSpecSecurely(
     return (await SwaggerParser.dereference(apiInput)) as OpenAPIV3.Document;
   }
 
-  // Resolve local + internal refs only; never follow http(s).
-  const resolverOptions = {
-    resolve: {
-      http: false as const,
-    },
-  };
+  // 1. Parse/fetch the entry document (http allowed so a URL input still loads),
+  //    without dereferencing, so we can inspect raw $ref values first.
+  const parsed = (await SwaggerParser.parse(apiInput)) as OpenAPIV3.Document;
 
-  // Parse without dereferencing so we can inspect raw $ref values first.
-  const parsed = (await SwaggerParser.parse(apiInput, resolverOptions)) as OpenAPIV3.Document;
+  // 2. Reject any external http(s) $ref embedded in the spec (SSRF guard).
   assertNoExternalRefs(parsed);
 
-  return (await SwaggerParser.dereference(apiInput, resolverOptions)) as OpenAPIV3.Document;
+  // 3. Dereference the already-loaded object with http disabled. No external
+  //    refs remain after the scan, so only local/internal refs are resolved and
+  //    nothing reaches out over the network.
+  return (await SwaggerParser.dereference(parsed, {
+    resolve: { http: false },
+  })) as OpenAPIV3.Document;
 }

--- a/tests/fixtures/multifile/openapi.json
+++ b/tests/fixtures/multifile/openapi.json
@@ -1,0 +1,17 @@
+{
+  "openapi": "3.0.0",
+  "info": { "title": "MultiFile", "version": "1.0.0" },
+  "servers": [{ "url": "https://api.example.com" }],
+  "paths": {
+    "/pets": {
+      "post": {
+        "operationId": "createPet",
+        "requestBody": {
+          "required": true,
+          "content": { "application/json": { "schema": { "$ref": "./refs/schemas.json#/Pet" } } }
+        },
+        "responses": { "201": { "description": "created" } }
+      }
+    }
+  }
+}

--- a/tests/fixtures/multifile/refs/schemas.json
+++ b/tests/fixtures/multifile/refs/schemas.json
@@ -1,0 +1,7 @@
+{
+  "Pet": {
+    "type": "object",
+    "properties": { "id": { "type": "integer" }, "name": { "type": "string" } },
+    "required": ["id"]
+  }
+}

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -139,6 +139,19 @@ describe('#68 external $ref SSRF guard', () => {
     expect(result.openapi).toBeDefined();
     expect(Object.keys(result.paths ?? {}).length).toBeGreaterThan(0);
   });
+
+  it('resolves relative $refs in a multi-file spec under the default guard', async () => {
+    // Regression: dereferencing must resolve relative file refs against the
+    // spec's directory (not the process cwd), so multi-file specs work.
+    const fixture = new URL('./fixtures/multifile/openapi.json', import.meta.url);
+    const result = await parseSpecSecurely(fileURLToPath(fixture), false);
+    const body = (result.paths?.['/pets'] as any)?.post?.requestBody?.content?.['application/json']
+      ?.schema;
+    // The `./refs/schemas.json#/Pet` ref must be inlined, not left dangling.
+    expect(body?.$ref).toBeUndefined();
+    expect(body?.properties?.name).toBeDefined();
+    expect(body?.properties?.id).toBeDefined();
+  });
 });
 
 // --- #4: tool name truncation ------------------------------------------------

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -3,6 +3,7 @@
  * Run with: npm test
  */
 import { describe, it, expect } from 'vitest';
+import { fileURLToPath } from 'node:url';
 import { OpenAPIV3 } from 'openapi-types';
 
 import { sanitizeForTemplate } from '../src/utils/helpers.js';
@@ -126,6 +127,17 @@ describe('#68 external $ref SSRF guard', () => {
     const result = await parseSpecSecurely(doc, false);
     expect(result.openapi).toBe('3.0.0');
     expect(result.paths?.['/x']).toBeDefined();
+  });
+
+  it('parses a spec from a path/URL-style string input under the default guard', async () => {
+    // Regression: the SSRF guard must not block loading the user-supplied input
+    // itself (a file path or http(s) URL). Only embedded external $refs are
+    // rejected. Previously `resolve: { http: false }` blocked fetching a URL
+    // input outright, breaking `-i https://.../openapi.json`.
+    const fixture = new URL('./fixtures/sample-api.json', import.meta.url);
+    const result = await parseSpecSecurely(fileURLToPath(fixture), false);
+    expect(result.openapi).toBeDefined();
+    expect(Object.keys(result.paths ?? {}).length).toBeGreaterThan(0);
   });
 });
 


### PR DESCRIPTION
## Problem

Running the generator against a remote spec URL fails on `main` (v4.0.0):

```
$ openapi-mcp-generator -i https://petstore3.swagger.io/api/v3/openapi.json -o ./out
Parsing OpenAPI spec: https://petstore3.swagger.io/api/v3/openapi.json
Error generating MCP server project: SyntaxError: Unable to resolve $ref pointer
  "https://petstore3.swagger.io/api/v3/openapi.json"
```

## Cause

The SSRF protection introduced in #69 set `resolve: { http: false }` for the whole parse to stop external `$ref` resolution. But that also stops SwaggerParser from fetching the **user-supplied input** when it's an `http(s)` URL — so the entry document can't even be loaded.

## Fix

The guard should reject external `$ref`s embedded *inside* the spec, not the trusted input the user passed. So:

1. Parse/fetch the entry document normally (a URL input loads).
2. Scan the parsed tree and reject any external `http(s)` `$ref` (`assertNoExternalRefs`).
3. Dereference the already-loaded object with `http: false` — safe because step 2 guaranteed no external refs remain to follow, so nothing reaches the network.

## Verification

- ✅ `-i https://petstore3.swagger.io/api/v3/openapi.json` now generates successfully (the reported command).
- ✅ Embedded external `$ref` (e.g. `http://169.254.169.254/...`) is still rejected with `ExternalRefError` (SSRF guard intact).
- ✅ Local file input still works.
- ✅ `--allow-external-refs` still works for URL inputs.
- Added a regression unit test parsing a spec from a path-style string input under the default guard.
- 48 tests pass; typecheck, format, build green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined OpenAPI external-reference protection: trusted input URLs/paths are no longer blocked, while external `$ref` dereferencing is still prevented when disabled.
  * Fixed relative `$ref` resolution in multi-file specs to use the spec’s directory, avoiding unresolved references.
  * Corrected the programmatic OpenAPI parsing flow to keep protection behavior consistent.

* **Tests**
  * Added regression tests covering the external `$ref` security guard.
  * Added/updated multi-file OpenAPI fixtures to verify correct dereferencing results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->